### PR TITLE
Replace 'displayed_problem' with 'selected_problem'

### DIFF
--- a/server/api/basic_flow_test.go
+++ b/server/api/basic_flow_test.go
@@ -127,7 +127,7 @@ func TestFlowBasic(t *testing.T) {
 		p := Problem{}
 		fetchProblem(t, r, u, gs.ProblemId, &p)
 		t.Logf("problem: %v", p)
-		gs = reportEvent(t, r, u, DISPLAYED_PROBLEM, "")
+		gs = reportEvent(t, r, u, SELECTED_PROBLEM, "")
 		gs = reportEvent(t, r, u, WORKING_ON_PROBLEM, "15")
 
 		// Have some incorrect answered for the first half of this round of problem solving

--- a/server/api/custom_handlers.go
+++ b/server/api/custom_handlers.go
@@ -183,7 +183,7 @@ func (a *Api) customListEvent(c *gin.Context) {
 	}
 
 	// Get recent events belonging to the specified user
-	sql := fmt.Sprintf("user_id=%d AND timestamp > now() - interval %d second AND event_type IN (\"%s\");", params.UserId, params.Seconds, strings.Join([]string{LOGGED_IN, DISPLAYED_PROBLEM, ANSWERED_PROBLEM, DONE_WATCHING_VIDEO}, "\",\""))
+	sql := fmt.Sprintf("user_id=%d AND timestamp > now() - interval %d second AND event_type IN (\"%s\");", params.UserId, params.Seconds, strings.Join([]string{LOGGED_IN, SELECTED_PROBLEM, ANSWERED_PROBLEM, DONE_WATCHING_VIDEO}, "\",\""))
 	events, status, msg, err := a.eventManager.CustomList(sql)
 	if HandleMngrRespWriteCtx(logPrefix, c, status, msg, err, events) != nil {
 		return

--- a/server/api/enums.go
+++ b/server/api/enums.go
@@ -4,7 +4,7 @@ package api // import "garydmenezes.com/mathgame/server/api"
 const (
 	// EventTypes
 	LOGGED_IN                  = "logged_in"                  // no value
-	DISPLAYED_PROBLEM          = "displayed_problem"          // int ProblemID
+	SELECTED_PROBLEM = "selected_problem"          // int ProblemID
 	WORKING_ON_PROBLEM         = "working_on_problem"         // int Duration in seconds
 	ANSWERED_PROBLEM           = "answered_problem"           // string Answer
 	ERROR_PLAYING_VIDEO        = "error_playing_video"        // string Error

--- a/server/api/process_events.go
+++ b/server/api/process_events.go
@@ -85,7 +85,7 @@ func (a *Api) processEvent(logPrefix string, c *gin.Context, event *Event, write
 		a.generateProblemsBackground(logPrefix, c, settings)
 	} else if event.EventType == SET_GAMESTATE_TARGET {
 		// TODO: validate
-	} else if event.EventType == DISPLAYED_PROBLEM {
+	} else if event.EventType == SELECTED_PROBLEM {
 		// TODO: validate problemID
 	} else if event.EventType == WORKING_ON_PROBLEM {
 		// TODO: validate duration
@@ -231,7 +231,7 @@ func (a *Api) processEvent(logPrefix string, c *gin.Context, event *Event, write
 	// Select a new problem
 	if changed_problem_settings {
 		// Get the most recent problem ids
-		sql := fmt.Sprintf("user_id=%d AND event_type='displayed_problem' AND timestamp >= NOW() - INTERVAL 30 MINUTE;", user.Id)
+		sql := fmt.Sprintf("user_id=%d AND event_type='selected_problem' LIMIT 20;", user.Id)
 		glog.Infof("recent problem ids sql: select * from events where %s\n", sql)
 		prevProblems, _, msg, err := a.eventManager.CustomList(sql)
 		if err != nil {

--- a/web/src/companion.js
+++ b/web/src/companion.js
@@ -172,7 +172,7 @@ const CompanionView = ({ token, url, user }) => {
         var e = json[i];
         if (e.event_type === "answered_problem") {
           attempts_buffer.push(e);
-        } else if (e.event_type === "displayed_problem") {
+        } else if (e.event_type === "selected_problem") {
           if (e.value !== gamestate.problem_id.toString()) {
             break;
           }

--- a/web/src/problem.js
+++ b/web/src/problem.js
@@ -133,7 +133,6 @@ const ProblemView = ({
 
   var minFontSize = 50;
 
-  postEvent("displayed_problem", gamestate.problem_id);
   var reporter = new EventReporterSingleton(postEvent, interval, postAnswer);
   reporter.problemWasDisplayed(gamestate.problem_id);
   var progress = String((100.0 * gamestate.solved) / gamestate.target) + "%";


### PR DESCRIPTION
We don't use all of these 'displayed_problem' events. We only need to log the selection of a problem.

See #122 for a python tool to amend previous events.

Fixes #122