### PR TITLE
Update llm generator to llm_0.1

### DIFF
--- a/server/api/generate_problems.go
+++ b/server/api/generate_problems.go
@@ -206,7 +206,7 @@ func (a *Api) generateProblems(logPrefix string, c *gin.Context, settings *Setti
 
 			// Convert to an api.Problem
 			model = &Problem{}
-			model.Generator = "llm_0.0"
+			model.Generator = llm_generator.VERSION
 			model.ProblemTypeBitmap = uint64(FeaturesToProblemType(p.Features))
 			model.Expression = strings.TrimSpace(p.Expression)
 			model.Answer = p.Answer

--- a/server/llm_generator/validate_problem.go
+++ b/server/llm_generator/validate_problem.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	openai "github.com/sashabaranov/go-openai"
@@ -17,6 +18,12 @@ const (
 )
 
 func ValidateProblem(p *Problem) error {
+	if strings.ContainsAny(p.Answer, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") {
+		msg := fmt.Sprintf("Answer contained text: %v\n", p)
+		glog.Info(msg)
+		return errors.New(msg)
+	}
+
 	c, err := common.ReadConfig("conf.json")
 	if err != nil {
 		glog.Fatal(err)
@@ -46,7 +53,7 @@ func ValidateProblem(p *Problem) error {
 	content := resp.Choices[0].Message.Content
 	if content != p.Answer {
 		msg := fmt.Sprintf("MISMATCH with OpenAI GPT4o validation: %s", content)
-		glog.Infof("%s", msg)
+		glog.Info(msg)
 		return errors.New(msg)
 	}
 	return nil


### PR DESCRIPTION
- correctly categorize word problems
- ensure numeric answers (e.g. '-' and '/' are allowed)

Production mitigation:
1. UPDATE problems SET problem_type_bitmap = problem_type_bitmap + 64 WHERE problem_type_bitmap < 64 AND expression LIKE '%text%';
2. SELECT * FROM problems WHERE answer REGEXP '[a-zA-Z]';
  - and manually correct these answers

Fixes #138