### PR TITLE
Add a compress-events command to compresses the events table.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GOPATH=$(HOME)/go
 SWAGGER=$(GOPATH)/bin/swagger
 RM=rm -rf
 
-all: build-api build-web
+all: build-api build-web build-cmds
 
 dev-api:
 	$(GOBIN)/apiserver -v 3 --logtostderr 1
@@ -27,6 +27,9 @@ build-api:
 	python3 server/code_generation/generate_handlers.py -c server/api/models.json -o server/api
 	$(GOFMT) -s .
 	$(GOBUILD) -o ./bin/apiserver ./cmd/apiserver/main.go
+
+build-cmds: build-api
+	$(GOBUILD) -o ./bin/compress_events ./cmd/compress_events/
 
 test: build-api test-api
 

--- a/cmd/compress_events/main.go
+++ b/cmd/compress_events/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"os"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/golang/glog"
+
+	"garydmenezes.com/mathgame/server/api"
+	"garydmenezes.com/mathgame/server/common"
+)
+
+func main() {
+	configPath := flag.String("config", "conf.json", "path to config JSON")
+	dryRun := flag.Bool("dry-run", false, "log planned updates and deletes without writing")
+	flag.Parse()
+
+	c, err := common.ReadConfig(*configPath)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	connectStr := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true&time_zone=UTC",
+		c.MySQLUser, c.MySQLPass, c.MySQLHost, c.MySQLPort, c.MySQLDatabase)
+	db, err := sql.Open("mysql", connectStr)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	defer db.Close()
+
+	if err := api.RunMigrations(db); err != nil {
+		glog.Fatalf("migrations: %v", err)
+	}
+
+	if *dryRun {
+		updates, toDelete, err := api.PlanCompress(db)
+		if err != nil {
+			glog.Fatal(err)
+		}
+		fmt.Fprintf(os.Stdout, "dry-run: would update %d rows, delete %d rows\n", len(updates), len(toDelete))
+		for _, e := range updates {
+			fmt.Fprintf(os.Stdout, "  update id=%d user_id=%d %s value=%s\n", e.Id, e.UserId, e.EventType, e.Value)
+		}
+		for _, e := range toDelete {
+			fmt.Fprintf(os.Stdout, "  delete id=%d user_id=%d\n", e.Id, e.UserId)
+		}
+		return
+	}
+
+	numUpdates, numDeletes, err := api.RunCompress(db)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	fmt.Fprintf(os.Stdout, "compressed: updated %d rows, deleted %d rows\n", numUpdates, numDeletes)
+}

--- a/server/api/event_compress.go
+++ b/server/api/event_compress.go
@@ -1,0 +1,133 @@
+// Package api contains event compression for the events table.
+package api
+
+import (
+	"database/sql"
+	"strconv"
+
+	"github.com/golang/glog"
+)
+
+// summableEventTypes are event types whose value is duration (ms) and can be summed when consecutive.
+var summableEventTypes = map[string]bool{
+	WORKING_ON_PROBLEM: true,
+	WATCHING_VIDEO:     true,
+}
+
+// CompressEvents returns updates (first row per run with value = sum) and events to delete (rest of each run).
+// Input events must be sorted by (user_id, id). Single-event runs and non-summable types are left unchanged.
+func CompressEvents(events []Event) (updates []Event, toDelete []Event) {
+	if len(events) == 0 {
+		return nil, nil
+	}
+	i := 0
+	for i < len(events) {
+		e := events[i]
+		if !summableEventTypes[e.EventType] {
+			i++
+			continue
+		}
+		runStart := i
+		sum, ok := parseInt64(e.Value)
+		if !ok {
+			i++
+			continue
+		}
+		j := i + 1
+		for j < len(events) && events[j].UserId == e.UserId && events[j].EventType == e.EventType {
+			v, ok := parseInt64(events[j].Value)
+			if !ok {
+				break
+			}
+			sum += v
+			j++
+		}
+		runEnd := j
+		if runEnd-runStart <= 1 {
+			i = runEnd
+			continue
+		}
+		first := events[runStart]
+		first.Value = strconv.FormatInt(sum, 10)
+		updates = append(updates, first)
+		for k := runStart + 1; k < runEnd; k++ {
+			toDelete = append(toDelete, events[k])
+		}
+		i = runEnd
+	}
+	return updates, toDelete
+}
+
+func parseInt64(s string) (int64, bool) {
+	n, err := strconv.ParseInt(s, 10, 64)
+	return n, err == nil
+}
+
+const (
+	selectEventsOrderedSQL = `SELECT id, timestamp, user_id, event_type, value FROM events ORDER BY user_id, id`
+	compressUpdateEventSQL = `UPDATE events SET timestamp=?, user_id=?, event_type=?, value=? WHERE id=? AND user_id=?`
+	compressDeleteEventSQL = `DELETE FROM events WHERE id=? AND user_id=?`
+)
+
+// PlanCompress reads all events and returns planned updates and deletes (no write). Used for dry-run.
+func PlanCompress(db *sql.DB) (updates []Event, toDelete []Event, err error) {
+	rows, err := db.Query(selectEventsOrderedSQL)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+
+	var events []Event
+	for rows.Next() {
+		var e Event
+		if err := rows.Scan(&e.Id, &e.Timestamp, &e.UserId, &e.EventType, &e.Value); err != nil {
+			return nil, nil, err
+		}
+		events = append(events, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	updates, toDelete = CompressEvents(events)
+	return updates, toDelete, nil
+}
+
+// RunCompress reads all events, compresses runs of summable types (update first row, delete rest), and applies changes in one transaction.
+func RunCompress(db *sql.DB) (numUpdates, numDeletes int, err error) {
+	updates, toDelete, err := PlanCompress(db)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return 0, 0, err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	for _, e := range updates {
+		_, err = tx.Exec(compressUpdateEventSQL, e.Timestamp, e.UserId, e.EventType, e.Value, e.Id, e.UserId)
+		if err != nil {
+			return 0, 0, err
+		}
+		numUpdates++
+	}
+	for _, e := range toDelete {
+		_, err = tx.Exec(compressDeleteEventSQL, e.Id, e.UserId)
+		if err != nil {
+			return 0, 0, err
+		}
+		numDeletes++
+	}
+
+	if err = tx.Commit(); err != nil {
+		return 0, 0, err
+	}
+	glog.Infof("compress_events: updated %d rows, deleted %d rows", numUpdates, numDeletes)
+	return numUpdates, numDeletes, nil
+}

--- a/server/api/event_compress_test.go
+++ b/server/api/event_compress_test.go
@@ -1,0 +1,177 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"garydmenezes.com/mathgame/server/common"
+)
+
+func ts(sec int64) time.Time {
+	return time.Unix(sec, 0).UTC()
+}
+
+func TestCompressEvents_Empty(t *testing.T) {
+	updates, toDelete := CompressEvents(nil)
+	if len(updates) != 0 || len(toDelete) != 0 {
+		t.Errorf("empty input: want updates=0, toDelete=0; got %d, %d", len(updates), len(toDelete))
+	}
+	updates, toDelete = CompressEvents([]Event{})
+	if len(updates) != 0 || len(toDelete) != 0 {
+		t.Errorf("empty slice: want updates=0, toDelete=0; got %d, %d", len(updates), len(toDelete))
+	}
+}
+
+func TestCompressEvents_SingleEvent(t *testing.T) {
+	events := []Event{
+		{Id: 1, UserId: 100, EventType: WATCHING_VIDEO, Value: "5000", Timestamp: ts(1)},
+	}
+	updates, toDelete := CompressEvents(events)
+	if len(updates) != 0 || len(toDelete) != 0 {
+		t.Errorf("single event: want no update/delete; got updates=%d, toDelete=%d", len(updates), len(toDelete))
+	}
+}
+
+func TestCompressEvents_ThreeConsecutiveWatchingVideo(t *testing.T) {
+	events := []Event{
+		{Id: 1, UserId: 100, EventType: WATCHING_VIDEO, Value: "5000", Timestamp: ts(1)},
+		{Id: 2, UserId: 100, EventType: WATCHING_VIDEO, Value: "5000", Timestamp: ts(2)},
+		{Id: 3, UserId: 100, EventType: WATCHING_VIDEO, Value: "5000", Timestamp: ts(3)},
+	}
+	updates, toDelete := CompressEvents(events)
+	if len(updates) != 1 {
+		t.Fatalf("updates: want 1, got %d", len(updates))
+	}
+	if updates[0].Id != 1 || updates[0].Value != "15000" || updates[0].UserId != 100 || updates[0].EventType != WATCHING_VIDEO {
+		t.Errorf("update: want id=1 value=15000; got %+v", updates[0])
+	}
+	if len(toDelete) != 2 {
+		t.Fatalf("toDelete: want 2, got %d", len(toDelete))
+	}
+	if toDelete[0].Id != 2 || toDelete[1].Id != 3 {
+		t.Errorf("toDelete ids: want [2,3], got [%d,%d]", toDelete[0].Id, toDelete[1].Id)
+	}
+}
+
+func TestCompressEvents_TwoConsecutiveWorkingOnProblem(t *testing.T) {
+	events := []Event{
+		{Id: 10, UserId: 1, EventType: WORKING_ON_PROBLEM, Value: "1000", Timestamp: ts(10)},
+		{Id: 11, UserId: 1, EventType: WORKING_ON_PROBLEM, Value: "2000", Timestamp: ts(11)},
+	}
+	updates, toDelete := CompressEvents(events)
+	if len(updates) != 1 || updates[0].Value != "3000" || updates[0].Id != 10 {
+		t.Errorf("updates: want one with value 3000 id 10; got %+v", updates)
+	}
+	if len(toDelete) != 1 || toDelete[0].Id != 11 {
+		t.Errorf("toDelete: want [id=11]; got %+v", toDelete)
+	}
+}
+
+func TestCompressEvents_InterleavedTypes(t *testing.T) {
+	events := []Event{
+		{Id: 1, UserId: 1, EventType: WORKING_ON_PROBLEM, Value: "1000", Timestamp: ts(1)},
+		{Id: 2, UserId: 1, EventType: WATCHING_VIDEO, Value: "5000", Timestamp: ts(2)},
+		{Id: 3, UserId: 1, EventType: WORKING_ON_PROBLEM, Value: "2000", Timestamp: ts(3)},
+	}
+	updates, toDelete := CompressEvents(events)
+	if len(updates) != 0 || len(toDelete) != 0 {
+		t.Errorf("interleaved: want no merge; got updates=%d, toDelete=%d", len(updates), len(toDelete))
+	}
+}
+
+func TestCompressEvents_TwoRunsSameType(t *testing.T) {
+	events := []Event{
+		{Id: 1, UserId: 1, EventType: WATCHING_VIDEO, Value: "5000", Timestamp: ts(1)},
+		{Id: 2, UserId: 1, EventType: WATCHING_VIDEO, Value: "5000", Timestamp: ts(2)},
+		{Id: 3, UserId: 1, EventType: SOLVED_PROBLEM, Value: "42", Timestamp: ts(3)},
+		{Id: 4, UserId: 1, EventType: WATCHING_VIDEO, Value: "1000", Timestamp: ts(4)},
+		{Id: 5, UserId: 1, EventType: WATCHING_VIDEO, Value: "2000", Timestamp: ts(5)},
+	}
+	updates, toDelete := CompressEvents(events)
+	if len(updates) != 2 {
+		t.Fatalf("updates: want 2 runs; got %d", len(updates))
+	}
+	if updates[0].Id != 1 || updates[0].Value != "10000" {
+		t.Errorf("first run: want id=1 value=10000; got id=%d value=%s", updates[0].Id, updates[0].Value)
+	}
+	if updates[1].Id != 4 || updates[1].Value != "3000" {
+		t.Errorf("second run: want id=4 value=3000; got id=%d value=%s", updates[1].Id, updates[1].Value)
+	}
+	if len(toDelete) != 2 {
+		t.Fatalf("toDelete: want 2; got %d", len(toDelete))
+	}
+	if toDelete[0].Id != 2 || toDelete[1].Id != 5 {
+		t.Errorf("toDelete ids: want [2,5]; got [%d,%d]", toDelete[0].Id, toDelete[1].Id)
+	}
+}
+
+func TestCompressEvents_NonNumericValueSkipsRun(t *testing.T) {
+	events := []Event{
+		{Id: 1, UserId: 1, EventType: WATCHING_VIDEO, Value: "5000", Timestamp: ts(1)},
+		{Id: 2, UserId: 1, EventType: WATCHING_VIDEO, Value: "bad", Timestamp: ts(2)},
+		{Id: 3, UserId: 1, EventType: WATCHING_VIDEO, Value: "5000", Timestamp: ts(3)},
+	}
+	updates, toDelete := CompressEvents(events)
+	if len(updates) != 0 || len(toDelete) != 0 {
+		t.Errorf("non-numeric in run: want no merge; got updates=%d, toDelete=%d", len(updates), len(toDelete))
+	}
+}
+
+func TestCompressEvents_NonSummableLeftAlone(t *testing.T) {
+	events := []Event{
+		{Id: 1, UserId: 1, EventType: SOLVED_PROBLEM, Value: "1", Timestamp: ts(1)},
+		{Id: 2, UserId: 1, EventType: SOLVED_PROBLEM, Value: "2", Timestamp: ts(2)},
+	}
+	updates, toDelete := CompressEvents(events)
+	if len(updates) != 0 || len(toDelete) != 0 {
+		t.Errorf("non-summable: want no merge; got updates=%d, toDelete=%d", len(updates), len(toDelete))
+	}
+}
+
+func TestRunCompress_Integration_ProgressUnchanged(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	ResetTestApi(c)
+	r := TestApi.GetRouter()
+	user := createTestUser(t, r, "auth0|compress-progress", "compress@test.com", "compressuser")
+
+	// Insert 3x watching_video 5000 ms each (total 15000 ms = 0.25 min, but progress rounds; we'll assert row count and same total)
+	_, err = TestApi.DB.Exec(
+		"INSERT INTO events (user_id, event_type, value) VALUES (?, ?, ?), (?, ?, ?), (?, ?, ?)",
+		user.Id, WATCHING_VIDEO, "5000",
+		user.Id, WATCHING_VIDEO, "5000",
+		user.Id, WATCHING_VIDEO, "5000",
+	)
+	if err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	// Get progress before compress (total_video_minutes: 15000/60000 = 0)
+	var count int
+	err = TestApi.DB.QueryRow("SELECT COUNT(*) FROM events WHERE user_id = ? AND event_type = ?", user.Id, WATCHING_VIDEO).Scan(&count)
+	if err != nil || count != 3 {
+		t.Fatalf("before: want 3 rows; got count=%d err=%v", count, err)
+	}
+
+	numUpdates, numDeletes, err := RunCompress(TestApi.DB)
+	if err != nil {
+		t.Fatalf("RunCompress: %v", err)
+	}
+	if numUpdates != 1 || numDeletes != 2 {
+		t.Errorf("RunCompress: want 1 update, 2 deletes; got %d, %d", numUpdates, numDeletes)
+	}
+
+	err = TestApi.DB.QueryRow("SELECT COUNT(*) FROM events WHERE user_id = ? AND event_type = ?", user.Id, WATCHING_VIDEO).Scan(&count)
+	if err != nil || count != 1 {
+		t.Fatalf("after: want 1 row; got count=%d err=%v", count, err)
+	}
+
+	var value string
+	err = TestApi.DB.QueryRow("SELECT value FROM events WHERE user_id = ? AND event_type = ?", user.Id, WATCHING_VIDEO).Scan(&value)
+	if err != nil || value != "15000" {
+		t.Errorf("merged value: want 15000; got %q err=%v", value, err)
+	}
+	// Sum preserved: 5000+5000+5000 = 15000 (any progress/totals query would see same total)
+}


### PR DESCRIPTION
Merges consecutive same-type summable events into the first row of each run (value = sum) and deletes the following redundant rows, preserving time order.

Fixes #11