### PR TITLE
Add API tests for settings, user, gamestate, and events endpoints

### DIFF
--- a/server/api/events_api_test.go
+++ b/server/api/events_api_test.go
@@ -1,0 +1,198 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"garydmenezes.com/mathgame/server/common"
+)
+
+func TestListEvents_ReturnsRecentEvents(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	api, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	user := createTestUser(t, r, "auth0|list-events", "listevents@test.com", "listeventsuser")
+
+	// Insert events directly
+	_, err = api.DB.Exec(
+		"INSERT INTO events (user_id, event_type, value) VALUES (?, ?, ?), (?, ?, ?), (?, ?, ?)",
+		user.Id, LOGGED_IN, "",
+		user.Id, SOLVED_PROBLEM, "1",
+		user.Id, ANSWERED_PROBLEM, "42",
+	)
+	if err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/api/v1/events/%d/3600?test_auth0_id=%s", user.Id, user.Auth0Id), nil)
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d body %s", http.StatusOK, resp.Code, resp.Body.Bytes())
+	}
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	var events []Event
+	if err := json.Unmarshal(body, &events); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// The endpoint filters to specific event types: LOGGED_IN, SELECTED_PROBLEM, ANSWERED_PROBLEM, SOLVED_PROBLEM, DONE_WATCHING_VIDEO
+	// LOGGED_IN, SOLVED_PROBLEM, and ANSWERED_PROBLEM should all be included
+	typeSet := make(map[string]bool)
+	for _, e := range events {
+		typeSet[e.EventType] = true
+	}
+	if !typeSet[LOGGED_IN] {
+		t.Errorf("expected LOGGED_IN event in results")
+	}
+	if !typeSet[SOLVED_PROBLEM] {
+		t.Errorf("expected SOLVED_PROBLEM event in results")
+	}
+	if !typeSet[ANSWERED_PROBLEM] {
+		t.Errorf("expected ANSWERED_PROBLEM event in results")
+	}
+}
+
+func TestListEvents_ExcludesFilteredTypes(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	api, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	user := createTestUser(t, r, "auth0|list-events-filter", "listfilter@test.com", "listfilteruser")
+
+	// Count baseline events from user creation
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/api/v1/events/%d/3600?test_auth0_id=%s", user.Id, user.Auth0Id), nil)
+	r.ServeHTTP(resp, req)
+	body, _ := ioutil.ReadAll(resp.Body)
+	var baseline []Event
+	json.Unmarshal(body, &baseline)
+	baselineCount := len(baseline)
+
+	// Insert event types that should be filtered out (WORKING_ON_PROBLEM, WATCHING_VIDEO)
+	_, err = api.DB.Exec(
+		"INSERT INTO events (user_id, event_type, value) VALUES (?, ?, ?), (?, ?, ?)",
+		user.Id, WORKING_ON_PROBLEM, "30000",
+		user.Id, WATCHING_VIDEO, "60000",
+	)
+	if err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", fmt.Sprintf("/api/v1/events/%d/3600?test_auth0_id=%s", user.Id, user.Auth0Id), nil)
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d body %s", http.StatusOK, resp.Code, resp.Body.Bytes())
+	}
+
+	body, _ = ioutil.ReadAll(resp.Body)
+	var events []Event
+	if err := json.Unmarshal(body, &events); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// WORKING_ON_PROBLEM and WATCHING_VIDEO should not appear, so count should be same as baseline
+	if len(events) != baselineCount {
+		t.Errorf("expected %d events (same as baseline, filtered types excluded), got %d", baselineCount, len(events))
+	}
+	for _, e := range events {
+		if e.EventType == WORKING_ON_PROBLEM || e.EventType == WATCHING_VIDEO {
+			t.Errorf("filtered event type %s should not appear in list", e.EventType)
+		}
+	}
+}
+
+func TestListEvents_NoExtraAfterCreation(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	_, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	user := createTestUser(t, r, "auth0|list-events-empty", "listempty@test.com", "listemptyuser")
+
+	// Get baseline count (user creation may generate events)
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/api/v1/events/%d/3600?test_auth0_id=%s", user.Id, user.Auth0Id), nil)
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d body %s", http.StatusOK, resp.Code, resp.Body.Bytes())
+	}
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	var events []Event
+	if err := json.Unmarshal(body, &events); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// All returned events should be valid filtered types
+	allowedTypes := map[string]bool{
+		LOGGED_IN: true, SELECTED_PROBLEM: true, ANSWERED_PROBLEM: true,
+		SOLVED_PROBLEM: true, DONE_WATCHING_VIDEO: true,
+	}
+	for _, e := range events {
+		if !allowedTypes[e.EventType] {
+			t.Errorf("unexpected event type %q in list response", e.EventType)
+		}
+	}
+}
+
+func TestListEvents_IsolatedPerUser(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	api, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	userA := createTestUser(t, r, "auth0|events-iso-a", "eventsisoa@test.com", "eventsisoa")
+	userB := createTestUser(t, r, "auth0|events-iso-b", "eventsisob@test.com", "eventsisob")
+
+	// Get user B's baseline event count (from user creation)
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/api/v1/events/%d/3600?test_auth0_id=%s", userB.Id, userB.Auth0Id), nil)
+	r.ServeHTTP(resp, req)
+	body, _ := ioutil.ReadAll(resp.Body)
+	var baselineB []Event
+	json.Unmarshal(body, &baselineB)
+	baselineCount := len(baselineB)
+
+	// Insert extra events for user A only
+	_, err = api.DB.Exec(
+		"INSERT INTO events (user_id, event_type, value) VALUES (?, ?, ?), (?, ?, ?)",
+		userA.Id, LOGGED_IN, "",
+		userA.Id, SOLVED_PROBLEM, "1",
+	)
+	if err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	// User B's count should not change
+	resp = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", fmt.Sprintf("/api/v1/events/%d/3600?test_auth0_id=%s", userB.Id, userB.Auth0Id), nil)
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d", http.StatusOK, resp.Code)
+	}
+	body, _ = ioutil.ReadAll(resp.Body)
+	var events []Event
+	if err := json.Unmarshal(body, &events); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(events) != baselineCount {
+		t.Errorf("user B should still have %d events (user A's events should not leak), got %d", baselineCount, len(events))
+	}
+}

--- a/server/api/gamestate_api_test.go
+++ b/server/api/gamestate_api_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"garydmenezes.com/mathgame/server/common"
+)
+
+func TestGetGamestate_ReturnsInitialState(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	api, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	user := createTestUser(t, r, "auth0|get-gamestate", "getgs@test.com", "getgsuser")
+	insertVideosAndUserHasVideo(t, api, user.Id, 3)
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/api/v1/gamestates/%d?test_auth0_id=%s", user.Id, user.Auth0Id), nil)
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body %s", http.StatusOK, resp.Code, resp.Body.Bytes())
+	}
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	var gs Gamestate
+	if err := json.Unmarshal(body, &gs); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if gs.UserId != user.Id {
+		t.Errorf("user_id: want %d, got %d", user.Id, gs.UserId)
+	}
+	if gs.Solved != 0 {
+		t.Errorf("solved: want 0 initially, got %d", gs.Solved)
+	}
+	if gs.VideoId == 0 {
+		t.Errorf("video_id should be auto-selected, got 0")
+	}
+}
+
+func TestGetGamestate_SelectsVideo(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	api, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	user := createTestUser(t, r, "auth0|gs-video-select", "gsvid@test.com", "gsviduser")
+	videoIDs := insertVideosAndUserHasVideo(t, api, user.Id, 3)
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/api/v1/gamestates/%d?test_auth0_id=%s", user.Id, user.Auth0Id), nil)
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d", http.StatusOK, resp.Code)
+	}
+	body, _ := ioutil.ReadAll(resp.Body)
+	var gs Gamestate
+	if err := json.Unmarshal(body, &gs); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// The selected video should be one of the user's videos
+	found := false
+	for _, vid := range videoIDs {
+		if gs.VideoId == vid {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("video_id %d not in user's video list %v", gs.VideoId, videoIDs)
+	}
+}

--- a/server/api/settings_api_test.go
+++ b/server/api/settings_api_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"garydmenezes.com/mathgame/server/common"
+)
+
+func TestGetSettings_ReturnsDefaults(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	_, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	user := createTestUser(t, r, "auth0|get-settings", "getsettings@test.com", "getsettingsuser")
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/api/v1/settings/%d?test_auth0_id=%s", user.Id, user.Auth0Id), nil)
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body %s", http.StatusOK, resp.Code, resp.Body.Bytes())
+	}
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	var s Settings
+	if err := json.Unmarshal(body, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.UserId != user.Id {
+		t.Errorf("user_id: want %d, got %d", user.Id, s.UserId)
+	}
+	if s.ProblemTypeBitmap != 1 {
+		t.Errorf("problem_type_bitmap: want 1 (default), got %d", s.ProblemTypeBitmap)
+	}
+	if s.TargetDifficulty != 3 {
+		t.Errorf("target_difficulty: want 3 (default), got %f", s.TargetDifficulty)
+	}
+	if s.TargetWorkPercentage != 70 {
+		t.Errorf("target_work_percentage: want 70 (default), got %d", s.TargetWorkPercentage)
+	}
+}
+
+func TestUpdateSettings_ChangesValues(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	_, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	user := createTestUser(t, r, "auth0|update-settings", "updatesettings@test.com", "updatesettingsuser")
+
+	// Update settings
+	updated := Settings{
+		UserId:               user.Id,
+		ProblemTypeBitmap:    3,
+		TargetDifficulty:     5,
+		TargetWorkPercentage: 50,
+	}
+	body, _ := json.Marshal(updated)
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/v1/settings/%d?test_auth0_id=%s", user.Id, user.Auth0Id), bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("POST settings: expected %d, got %d body %s", http.StatusOK, resp.Code, resp.Body.Bytes())
+	}
+
+	// Verify via GET
+	resp = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", fmt.Sprintf("/api/v1/settings/%d?test_auth0_id=%s", user.Id, user.Auth0Id), nil)
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("GET settings: expected %d, got %d", http.StatusOK, resp.Code)
+	}
+	body, _ = ioutil.ReadAll(resp.Body)
+	var s Settings
+	if err := json.Unmarshal(body, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.ProblemTypeBitmap != 3 {
+		t.Errorf("problem_type_bitmap: want 3, got %d", s.ProblemTypeBitmap)
+	}
+	if s.TargetDifficulty != 5 {
+		t.Errorf("target_difficulty: want 5, got %f", s.TargetDifficulty)
+	}
+	if s.TargetWorkPercentage != 50 {
+		t.Errorf("target_work_percentage: want 50, got %d", s.TargetWorkPercentage)
+	}
+}
+
+func TestUpdateSettings_GeneratesChangeEvents(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	api, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	user := createTestUser(t, r, "auth0|settings-events", "settingsevents@test.com", "settingseventsuser")
+
+	// Count baseline events from user creation
+	var baselineWorkPct, baselineBitmap int
+	api.DB.QueryRow("SELECT COUNT(*) FROM events WHERE user_id = ? AND event_type = ?", user.Id, SET_TARGET_WORK_PERCENTAGE).Scan(&baselineWorkPct)
+	api.DB.QueryRow("SELECT COUNT(*) FROM events WHERE user_id = ? AND event_type = ?", user.Id, SET_PROBLEM_TYPE_BITMAP).Scan(&baselineBitmap)
+
+	// Change target_work_percentage from default (70) to 40, keep bitmap same
+	updated := Settings{
+		UserId:               user.Id,
+		ProblemTypeBitmap:    1, // same as default
+		TargetDifficulty:     3, // same as default
+		TargetWorkPercentage: 40,
+	}
+	body, _ := json.Marshal(updated)
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/v1/settings/%d?test_auth0_id=%s", user.Id, user.Auth0Id), bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("POST settings: expected %d, got %d body %s", http.StatusOK, resp.Code, resp.Body.Bytes())
+	}
+
+	// Check that exactly one new SET_TARGET_WORK_PERCENTAGE event was generated
+	var count int
+	err = api.DB.QueryRow(
+		"SELECT COUNT(*) FROM events WHERE user_id = ? AND event_type = ?",
+		user.Id, SET_TARGET_WORK_PERCENTAGE,
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("query events: %v", err)
+	}
+	if count != baselineWorkPct+1 {
+		t.Errorf("expected %d SET_TARGET_WORK_PERCENTAGE events (baseline %d + 1), got %d", baselineWorkPct+1, baselineWorkPct, count)
+	}
+
+	// Bitmap was unchanged, so no new event
+	err = api.DB.QueryRow(
+		"SELECT COUNT(*) FROM events WHERE user_id = ? AND event_type = ?",
+		user.Id, SET_PROBLEM_TYPE_BITMAP,
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("query events: %v", err)
+	}
+	if count != baselineBitmap {
+		t.Errorf("expected %d SET_PROBLEM_TYPE_BITMAP events (unchanged from baseline), got %d", baselineBitmap, count)
+	}
+}

--- a/server/api/user_api_test.go
+++ b/server/api/user_api_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"garydmenezes.com/mathgame/server/common"
+)
+
+func TestGetUser_ReturnsCreatedUser(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	_, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	user := createTestUser(t, r, "auth0|get-user-test", "getuser@test.com", "getusertest")
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/api/v1/users/%s?test_auth0_id=%s", url.PathEscape(user.Auth0Id), user.Auth0Id), nil)
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body %s", http.StatusOK, resp.Code, resp.Body.Bytes())
+	}
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	var u User
+	if err := json.Unmarshal(body, &u); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if u.Auth0Id != user.Auth0Id {
+		t.Errorf("auth0_id: want %s, got %s", user.Auth0Id, u.Auth0Id)
+	}
+	if u.Email != user.Email {
+		t.Errorf("email: want %s, got %s", user.Email, u.Email)
+	}
+	if u.Username != user.Username {
+		t.Errorf("username: want %s, got %s", user.Username, u.Username)
+	}
+}
+
+func TestUpdateUser_ChangesFields(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	_, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	user := createTestUser(t, r, "auth0|update-user-test", "updateuser@test.com", "updateusertest")
+
+	// Update via POST /users/:auth0_id
+	updated := User{
+		Auth0Id:  user.Auth0Id,
+		Email:    "newemail@test.com",
+		Username: "newusername",
+	}
+	body, _ := json.Marshal(updated)
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/v1/users/%s?test_auth0_id=%s", url.PathEscape(user.Auth0Id), user.Auth0Id), bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("POST user update: expected %d, got %d body %s", http.StatusOK, resp.Code, resp.Body.Bytes())
+	}
+
+	// Verify via GET
+	resp = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", fmt.Sprintf("/api/v1/users/%s?test_auth0_id=%s", url.PathEscape(user.Auth0Id), user.Auth0Id), nil)
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("GET user: expected %d, got %d", http.StatusOK, resp.Code)
+	}
+	body, _ = ioutil.ReadAll(resp.Body)
+	var u User
+	if err := json.Unmarshal(body, &u); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if u.Email != "newemail@test.com" {
+		t.Errorf("email: want newemail@test.com, got %s", u.Email)
+	}
+	if u.Username != "newusername" {
+		t.Errorf("username: want newusername, got %s", u.Username)
+	}
+}


### PR DESCRIPTION
Cover previously untested endpoints: GET/POST settings, GET/POST users, GET gamestates, and GET events list with filtering and isolation checks.