### PR TITLE
Fix event parsing to handle decimal values.

### DIFF
--- a/server/api/event_compress.go
+++ b/server/api/event_compress.go
@@ -29,14 +29,14 @@ func CompressEvents(events []Event) (updates []Event, toDelete []Event) {
 			continue
 		}
 		runStart := i
-		sum, ok := parseInt64(e.Value)
+		sum, ok := parseEventDurationMs(e.Value)
 		if !ok {
 			i++
 			continue
 		}
 		j := i + 1
 		for j < len(events) && events[j].UserId == e.UserId && events[j].EventType == e.EventType {
-			v, ok := parseInt64(events[j].Value)
+			v, ok := parseEventDurationMs(events[j].Value)
 			if !ok {
 				break
 			}
@@ -59,9 +59,19 @@ func CompressEvents(events []Event) (updates []Event, toDelete []Event) {
 	return updates, toDelete
 }
 
-func parseInt64(s string) (int64, bool) {
-	n, err := strconv.ParseInt(s, 10, 64)
-	return n, err == nil
+// parseEventDurationMs parses an event row's value as a millisecond duration.
+// Tolerates decimal strings (e.g. watching_video posts durations as floats like
+// "505.9579275207507") by falling back to ParseFloat and truncating toward zero.
+// Returns (0, false) only when the string cannot be parsed at all.
+func parseEventDurationMs(s string) (int64, bool) {
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return n, true
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+	return int64(f), true
 }
 
 const (

--- a/server/api/event_compress_test.go
+++ b/server/api/event_compress_test.go
@@ -105,6 +105,28 @@ func TestCompressEvents_TwoRunsSameType(t *testing.T) {
 	}
 }
 
+func TestCompressEvents_DecimalValuesCompress(t *testing.T) {
+	// watching_video events are posted as floating-point millisecond strings
+	// (e.g. "505.9579275207507") because the frontend computes the delta with
+	// floating-point math. Compression must tolerate these.
+	events := []Event{
+		{Id: 1, UserId: 1, EventType: WATCHING_VIDEO, Value: "505.9579275207507", Timestamp: ts(1)},
+		{Id: 2, UserId: 1, EventType: WATCHING_VIDEO, Value: "500.5", Timestamp: ts(2)},
+		{Id: 3, UserId: 1, EventType: WATCHING_VIDEO, Value: "499.1", Timestamp: ts(3)},
+	}
+	updates, toDelete := CompressEvents(events)
+	if len(updates) != 1 {
+		t.Fatalf("updates: want 1, got %d", len(updates))
+	}
+	// int64(505.95...) + int64(500.5) + int64(499.1) = 505 + 500 + 499 = 1504
+	if updates[0].Id != 1 || updates[0].Value != "1504" {
+		t.Errorf("merged: want id=1 value=1504; got id=%d value=%q", updates[0].Id, updates[0].Value)
+	}
+	if len(toDelete) != 2 || toDelete[0].Id != 2 || toDelete[1].Id != 3 {
+		t.Errorf("toDelete ids: want [2,3]; got %+v", toDelete)
+	}
+}
+
 func TestCompressEvents_NonNumericValueSkipsRun(t *testing.T) {
 	events := []Event{
 		{Id: 1, UserId: 1, EventType: WATCHING_VIDEO, Value: "5000", Timestamp: ts(1)},

--- a/server/api/statistics_handlers.go
+++ b/server/api/statistics_handlers.go
@@ -4,7 +4,6 @@ package api
 import (
 	"database/sql"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -213,22 +212,24 @@ func (a *Api) mergeProgressEventsIntoCache(logPrefix string, userID uint32, even
 	const msPerMinute = 60000
 	var totalDelta int64
 	var workDelta, videoDelta int64
+	// Accumulate per-month totals in milliseconds and divide once at the end, to
+	// match how fullProgressBackfill computes it.
 	monthDeltas := make(map[string]struct {
-		solved   int64
-		workMin  int64
-		videoMin int64
+		solved  int64
+		workMs  int64
+		videoMs int64
 	})
 	for _, e := range events {
 		switch e.eventType {
 		case SOLVED_PROBLEM:
 			totalDelta++
 		case WORKING_ON_PROBLEM:
-			v, _ := strconv.ParseInt(e.value, 10, 64)
+			v, _ := parseEventDurationMs(e.value)
 			if v > 0 {
 				workDelta += v
 			}
 		case WATCHING_VIDEO:
-			v, _ := strconv.ParseInt(e.value, 10, 64)
+			v, _ := parseEventDurationMs(e.value)
 			if v > 0 {
 				videoDelta += v
 			}
@@ -240,14 +241,14 @@ func (a *Api) mergeProgressEventsIntoCache(logPrefix string, userID uint32, even
 			case SOLVED_PROBLEM:
 				d.solved++
 			case WORKING_ON_PROBLEM:
-				v, _ := strconv.ParseInt(e.value, 10, 64)
+				v, _ := parseEventDurationMs(e.value)
 				if v > 0 {
-					d.workMin += v / msPerMinute
+					d.workMs += v
 				}
 			case WATCHING_VIDEO:
-				v, _ := strconv.ParseInt(e.value, 10, 64)
+				v, _ := parseEventDurationMs(e.value)
 				if v > 0 {
-					d.videoMin += v / msPerMinute
+					d.videoMs += v
 				}
 			}
 			monthDeltas[month] = d
@@ -270,6 +271,8 @@ func (a *Api) mergeProgressEventsIntoCache(logPrefix string, userID uint32, even
 	}
 
 	for month, d := range monthDeltas {
+		workMin := d.workMs / msPerMinute
+		videoMin := d.videoMs / msPerMinute
 		_, err = a.DB.Exec(`
 			INSERT INTO statistics_monthly (user_id, month, total_problems_solved, total_work_minutes, total_video_minutes)
 			VALUES (?, ?, ?, ?, ?)
@@ -277,7 +280,7 @@ func (a *Api) mergeProgressEventsIntoCache(logPrefix string, userID uint32, even
 				total_problems_solved = total_problems_solved + VALUES(total_problems_solved),
 				total_work_minutes = total_work_minutes + VALUES(total_work_minutes),
 				total_video_minutes = total_video_minutes + VALUES(total_video_minutes)`,
-			userID, month, d.solved, d.workMin, d.videoMin,
+			userID, month, d.solved, workMin, videoMin,
 		)
 		if err != nil {
 			return 0, err

--- a/server/api/statistics_test.go
+++ b/server/api/statistics_test.go
@@ -197,3 +197,127 @@ func TestUpdateStatisticsForUser_BackfillsCacheAndMeta(t *testing.T) {
 		t.Error("statistics_cache_meta.last_event_id should be set")
 	}
 }
+
+// Regression: watching_video events are posted by the frontend with decimal
+// millisecond values (e.g. "505.9579275207507"). Before the fix, the incremental
+// merge path used strconv.ParseInt which fails on decimals and silently returned 0,
+// so every post-cache video event contributed 0 min to both totals and monthly.
+func TestUpdateStatisticsForUser_IncrementalHandlesDecimalWatchingVideo(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	api, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	user := createTestUser(t, r, "auth0|stats-decimal", "decimal@test.com", "decimaluser")
+
+	// First call: no events yet, triggers fullProgressBackfill and establishes cache_meta.
+	if err := api.UpdateStatisticsForUser("[test]", user.Id); err != nil {
+		t.Fatalf("initial UpdateStatisticsForUser: %v", err)
+	}
+
+	// Now insert decimal-valued watching_video events. 120 events * ~506 ms ≈ 60720 ms ≈ 1 min.
+	tx, err := api.DB.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	stmt, err := tx.Prepare("INSERT INTO events (user_id, event_type, value) VALUES (?, ?, ?)")
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	for i := 0; i < 120; i++ {
+		if _, err := stmt.Exec(user.Id, WATCHING_VIDEO, "505.9579275207507"); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	_ = stmt.Close()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Second call: takes the incremental path.
+	if err := api.UpdateStatisticsForUser("[test]", user.Id); err != nil {
+		t.Fatalf("incremental UpdateStatisticsForUser: %v", err)
+	}
+
+	var totalVideo int64
+	err = api.DB.QueryRow(
+		"SELECT total_video_minutes FROM statistics_totals WHERE user_id = ?",
+		user.Id,
+	).Scan(&totalVideo)
+	if err != nil {
+		t.Fatalf("read statistics_totals: %v", err)
+	}
+	// int64(505.9579...) = 505; 505 * 120 = 60600 ms = 1 minute (floor).
+	if totalVideo != 1 {
+		t.Errorf("total_video_minutes: want 1, got %d", totalVideo)
+	}
+
+	var monthVideo int64
+	err = api.DB.QueryRow(
+		"SELECT total_video_minutes FROM statistics_monthly WHERE user_id = ? ORDER BY month DESC LIMIT 1",
+		user.Id,
+	).Scan(&monthVideo)
+	if err != nil {
+		t.Fatalf("read statistics_monthly: %v", err)
+	}
+	if monthVideo != 1 {
+		t.Errorf("monthly total_video_minutes: want 1, got %d", monthVideo)
+	}
+}
+
+// Regression: the monthly branch of mergeProgressEventsIntoCache used to divide
+// per-event (d.workMin += v / 60000), which rounded every sub-minute event to 0 and
+// made monthly stats dramatically under-count when event granularity is small
+// (the frontend posts working_on_problem events every 500 ms).
+func TestUpdateStatisticsForUser_IncrementalMonthlySumsThenDivides(t *testing.T) {
+	c, err := common.ReadConfig("../../test_conf.json")
+	if err != nil {
+		t.Fatalf("Couldn't read config: %v", err)
+	}
+	api, r, cleanup := setupTestAPI(t, c)
+	defer cleanup()
+	user := createTestUser(t, r, "auth0|stats-sub-min", "submin@test.com", "subminuser")
+
+	// First call: establish cache_meta with no events, so the next call is incremental.
+	if err := api.UpdateStatisticsForUser("[test]", user.Id); err != nil {
+		t.Fatalf("initial UpdateStatisticsForUser: %v", err)
+	}
+
+	// 180 events * 500 ms = 90000 ms = 1 minute (with leftover 30000 ms).
+	tx, err := api.DB.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	stmt, err := tx.Prepare("INSERT INTO events (user_id, event_type, value) VALUES (?, ?, ?)")
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	for i := 0; i < 180; i++ {
+		if _, err := stmt.Exec(user.Id, WORKING_ON_PROBLEM, "500"); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	_ = stmt.Close()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	if err := api.UpdateStatisticsForUser("[test]", user.Id); err != nil {
+		t.Fatalf("incremental UpdateStatisticsForUser: %v", err)
+	}
+
+	var monthWork int64
+	err = api.DB.QueryRow(
+		"SELECT total_work_minutes FROM statistics_monthly WHERE user_id = ? ORDER BY month DESC LIMIT 1",
+		user.Id,
+	).Scan(&monthWork)
+	if err != nil {
+		t.Fatalf("read statistics_monthly: %v", err)
+	}
+	// 180 * 500 = 90000 ms. Pre-fix: per-event 500/60000 = 0 each -> 0 min.
+	// Post-fix: sum first, 90000/60000 = 1 min.
+	if monthWork != 1 {
+		t.Errorf("monthly total_work_minutes: want 1, got %d", monthWork)
+	}
+}


### PR DESCRIPTION
- 'watch_video' events are recorded as decimals (unlike 'working_on_problem', which has always been an integer)
- update event compression AND stats generation to handle this